### PR TITLE
fix: only remove boundaries if present in list

### DIFF
--- a/R/filter_boundaries.R
+++ b/R/filter_boundaries.R
@@ -29,19 +29,25 @@ filter_boundaries <- function(y, boundaries) {
 
   # Pull out boundaries for each state if there are no data for that state
   if (length(y[y > southern_WA]) == 0) {
-    boundaries <- boundaries[
-      -which(names(boundaries) %in% c("WA", "wa", "washington", "Washington"))
-    ]
+    if(names(boundaries) %in% c("WA", "wa", "washington", "Washington")){
+      boundaries <- boundaries[
+        -which(names(boundaries) %in% c("WA", "wa", "washington", "Washington"))
+      ]
+    }
   }
   if (length(y[y < southern_WA]) == 0 & length(y[y > southern_OR]) == 0) {
-    boundaries <- boundaries[
-      -which(names(boundaries) %in% c("OR", "or", "oregon", "Oregon"))
-    ]
+    if(names(boundaries) %in% c("OR", "or", "oregon", "Oregon")){
+      boundaries <- boundaries[
+        -which(names(boundaries) %in% c("OR", "or", "oregon", "Oregon"))
+      ]
+    }
   }
   if (length(y[y < southern_OR]) == 0) {
-    boundaries <- boundaries[
-      -which(names(boundaries) %in% c("CA", "ca", "california", "California"))
-    ]
+    if(names(boundaries) %in% c("CA", "ca", "california", "California")){
+      boundaries <- boundaries[
+        -which(names(boundaries) %in% c("CA", "ca", "california", "California"))
+      ]
+    }
   }
 
   boundaries_tops <- shrink_boundary(purrr::map(boundaries, 1), max(y), ">")


### PR DESCRIPTION
I was having the issue where I was getting an empty vector for boundaries.  Once I dug into it, I found that the boundary check was not robust enough when the boundary was set within a state area.  This fix is fairly unsophisticated but addressed the problem.  I think this could be done better, but I wanted to open a pull request for you to consider adding this fix or adding a better fix in the main branch.  

This pull request should also be considered in tandem with the other open pull request that adds boundaries to the initial call for `runsdmTMB()`.  Having both the functionality to do boundary calculations on existing index estimates or incorporating them in the initial estimation phase provides useful versatility.  