### PR TITLE
add testthat tests, starting with consistency of configuration file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Imports:
     viridis
 Suggests:
     knitr,
-    testthat
+    testthat (>= 3.0.0)
 Remotes:
     github::pfmc-assessments/nwfscSurvey
 Encoding: UTF-8
@@ -55,3 +55,4 @@ LazyData: true
 LazyDataCompression: xz
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
+Config/testthat/edition: 3

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
+library(testthat)
+library(indexwc)
+
+test_check("indexwc")

--- a/tests/testthat/test-configuration.R
+++ b/tests/testthat/test-configuration.R
@@ -11,10 +11,8 @@ test_that("configuration.rda matches configuration.csv", {
     ))
 
     # Check if the configuration and configuration_csv tibbles are identical
-    expect_true(
-        all.equal(
-            indexwc::configuration,
-            configuration_csv
-        )
+    expect_equal(
+        indexwc::configuration,
+        configuration_csv
     )
 })

--- a/tests/testthat/test-configuration.R
+++ b/tests/testthat/test-configuration.R
@@ -1,0 +1,20 @@
+# check that configuration.rda matches configuration.csv
+test_that("configuration.rda matches configuration.csv", {
+    # Note: configuration.rda is automatically loaded when package is installed
+
+    # Read the CSV version of configuration
+    # (reading from github because data-raw folder doesn't seem to be visible
+    # to the installed package)
+    configuration_csv <- tibble::as_tibble(read.csv(
+        # file.path("data-raw", "configuration.csv")
+        "https://raw.githubusercontent.com/pfmc-assessments/indexwc/refs/heads/main/data-raw/configuration.csv"
+    ))
+
+    # Check if the configuration and configuration_csv tibbles are identical
+    expect_true(
+        all.equal(
+            indexwc::configuration,
+            configuration_csv
+        )
+    )
+})


### PR DESCRIPTION
- thanks to @chantelwetzel-noaa for the idea: https://github.com/pfmc-assessments/indexwc/pull/60#issuecomment-3019558305

## **What was changed/addressed**
<!--- In 20 words or less concisely describe what was changed or addressed. -->
<!--- Detailed notes should be in the related issue rather than here. -->

Adds testthat framework and a single test. Would be good to add lots more.