### PR TITLE
add some simple tests for configuration tibble

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
+library(testthat)
+library(indexwc)
+
+test_check("indexwc")

--- a/tests/testthat/test-configuration.R
+++ b/tests/testthat/test-configuration.R
@@ -1,0 +1,64 @@
+# This test file checks the contents of the configuration.rda data file
+# to ensure it contains all expected columns and values.
+# It also verifies that the values in certain columns match expected sets.
+# If you add new columns or change the configuration, update these tests accordingly.
+test_that("configuration.rda contains what we expect", {
+    # Note: configuration.rda is automatically loaded when package is installed
+
+    # Check if the configuration file contains all the expected stuff
+    expect_true(
+        all(
+            c(
+                "species",
+                "fxn",
+                "source",
+                "family",
+                "formula",
+                "min_depth",
+                "max_depth",
+                "min_latitude",
+                "max_latitude",
+                "min_year",
+                "max_year",
+                "anisotropy",
+                "knots",
+                "spatiotemporal1",
+                "spatiotemporal2",
+                "share_range",
+                "used"
+            ) %in%
+                names(indexwc::configuration)
+        )
+    )
+    # Check that all values in the 'source' column are from the expected set
+    expect_true(
+        all(
+            unique(indexwc::configuration[["source"]]) %in%
+                c("NWFSC.Combo", "Triennial", "AFSC.Slope", "NWFSC.Slope")
+        )
+    )
+
+    # Check that all values in the 'spatiotemporal1' column are either "iid" or "off"
+    expect_true(
+        all(
+            unique(indexwc::configuration[["spatiotemporal1"]]) %in%
+                c("iid", "off")
+        )
+    )
+
+    # Check that all values in the 'spatiotemporal2' column are either "iid" or "off"
+    expect_true(
+        all(
+            unique(indexwc::configuration[["spatiotemporal2"]]) %in%
+                c("iid", "off")
+        )
+    )
+
+    # Check that the 'used' column contains only logical values or NA
+    expect_true(
+        all(
+            is.na(indexwc::configuration[["used"]]) |
+                is.logical(indexwc::configuration[["used"]])
+        )
+    )
+})


### PR DESCRIPTION
## **What was changed/addressed**
Adds testing via {testthat} back to the package.

No longer testing for consistency between csv and rda versions of the tibble, instead focused on content. Test could be expanded or modified as needed in the future.